### PR TITLE
Give access to legacy ~/.icons custom cursor themes

### DIFF
--- a/io.github.mpc_qt.mpc-qt.yml
+++ b/io.github.mpc_qt.mpc-qt.yml
@@ -35,6 +35,9 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mpris.MediaPlayer2.MpcQt
   - --system-talk-name=org.freedesktop.UDisks2
+# Give access to legacy ~/.icons downloaded mouse cursor themes path, use full home folder to avoid finish-args-legacy-icon-folder-permission error
+  - --filesystem=home:ro
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons:~/.icons
 cleanup:
   - '*.a'
   - '*.la'


### PR DESCRIPTION
The ~/.icons path is still used by KDE and other DEs instead of ~/.local/share/icons/ to store downloaded mouse custom cursor themes.