### PR TITLE
Update runtime and reduce final size

### DIFF
--- a/io.github.mpc_qt.mpc-qt.yml
+++ b/io.github.mpc_qt.mpc-qt.yml
@@ -1,10 +1,9 @@
 app-id: io.github.mpc_qt.mpc-qt
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: mpc-qt
 rename-icon: mpc-qt
-copy-icon: true
 add-build-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     version: '24.08'
@@ -51,7 +50,6 @@ modules:
   - name: mpc-qt
     buildsystem: cmake-ninja
     config-opts:
-      - -DCMAKE_PREFIX_PATH=/app/boost
       - -DMPCQT_VERSION=25.07-flatpak
     sources:
       - type: git
@@ -76,6 +74,9 @@ modules:
           - -Dalsa=disabled
           - -Dmanpage-build=disabled
           - -Dvulkan=enabled
+          - -Dx11=enabled
+          - -Dwayland=enabled
+          - -Ddrm=enabled
         sources:
           - type: archive
             url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.40.0.tar.gz
@@ -262,8 +263,8 @@ modules:
       - name: boost
         buildsystem: simple
         build-commands:
-          - ./bootstrap.sh
-          - ./b2 install --prefix=/app/boost
+          - ./bootstrap.sh --with-libraries=stacktrace,headers
+          - ./b2 install variant=release link=shared runtime-link=shared --prefix=/app
         sources:
           - type: archive
             url: https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-cmake.tar.gz


### PR DESCRIPTION
Don't build unneeded parts of Boost, update runtime.
Don't use a different folder for Boost in the flatpak as it doesn't get cleaned up by default. This means that the final size was much larger.
Be verbose about mpv options needed for hardware decoding.
Don't copy a duplicate icon with the original name.