### PR TITLE
manifest: Add missing org.freedesktop.login1 dbus access

### DIFF
--- a/io.github.mpc_qt.mpc-qt.yml
+++ b/io.github.mpc_qt.mpc-qt.yml
@@ -26,8 +26,9 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=xdg-run/gamescope-0:ro
   - --filesystem=xdg-run/pipewire-0:ro
-  - --talk-name=org.freedesktop.ScreenSaver
   - --own-name=org.mpris.MediaPlayer2.MpcQt
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --system-talk-name=org.freedesktop.login1
   - --system-talk-name=org.freedesktop.UDisks2
 # Access to home folder is needed for external subtitles and for downloaded mouse cursor
   - --filesystem=home:ro


### PR DESCRIPTION
Required for Hibernate, Suspend and PowerOff after playback.

Link: https://github.com/mpc-qt/mpc-qt/issues/814