### PR TITLE
data: Remove "Audio" and "Video" categories from .desktop file

### DIFF
--- a/io.github.mpc_qt.mpc-qt.yml
+++ b/io.github.mpc_qt.mpc-qt.yml
@@ -61,6 +61,7 @@ modules:
           - mpc-qt-wayland-option-on-wayland.patch
           - mpc-qt-differentiate-between-x11-and-xwayland.patch
           - mpc-qt-wayland-mode-on-first-start.patch
+          - mpq-qt-desktop-categories.patch
     modules:
       - name: libmpv
         cleanup:

--- a/mpq-qt-desktop-categories.patch
+++ b/mpq-qt-desktop-categories.patch
@@ -1,0 +1,30 @@
+From e2624ce75913e34d8b850020c1b54058f130247d Mon Sep 17 00:00:00 2001
+Message-ID: <e2624ce75913e34d8b850020c1b54058f130247d.1777007360.git.3265870+tbertels@users.noreply.github.com>
+From: Thomas Bertels <3265870+tbertels@users.noreply.github.com>
+Date: Thu, 23 Apr 2026 20:16:18 +0200
+Subject: [PATCH] data: Remove "Audio" and "Video" categories from .desktop
+ file
+
+Plasma Discover uses the "Audio" and "Video" categories to exclude apps
+from respectively video and audio players categories.
+The "AudioVideo" category already covers both.
+---
+ data/io.github.mpc_qt.mpc-qt.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/io.github.mpc_qt.mpc-qt.desktop b/data/io.github.mpc_qt.mpc-qt.desktop
+index 689244fd..9cd65207 100644
+--- a/data/io.github.mpc_qt.mpc-qt.desktop
++++ b/data/io.github.mpc_qt.mpc-qt.desktop
+@@ -10,7 +10,7 @@ TryExec=mpc-qt
+ Icon=mpc-qt
+ StartupNotify=true
+ Terminal=false
+-Categories=Qt;AudioVideo;Audio;Video;Player;TV;
++Categories=Qt;AudioVideo;Player;TV;
+ MimeType=application/ogg;application/x-ogg;application/mxf;application/sdp;application/smil;application/x-smil;application/streamingmedia;application/x-streamingmedia;application/vnd.rn-realmedia;application/vnd.rn-realmedia-vbr;audio/aac;audio/x-aac;audio/vnd.dolby.heaac.1;audio/vnd.dolby.heaac.2;audio/aiff;audio/x-aiff;audio/m4a;audio/x-m4a;application/x-extension-m4a;audio/mp1;audio/x-mp1;audio/mp2;audio/x-mp2;audio/mp3;audio/x-mp3;audio/mpeg;audio/mpeg2;audio/mpeg3;audio/mpegurl;audio/x-mpegurl;audio/mpg;audio/x-mpg;audio/rn-mpeg;audio/musepack;audio/x-musepack;audio/ogg;audio/scpls;audio/x-scpls;audio/vnd.rn-realaudio;audio/wav;audio/x-pn-wav;audio/x-pn-windows-pcm;audio/x-realaudio;audio/x-pn-realaudio;audio/x-ms-wma;audio/x-pls;audio/x-wav;video/mpeg;video/x-mpeg2;video/x-mpeg3;video/mp4v-es;video/x-m4v;video/mp4;application/x-extension-mp4;video/divx;video/vnd.divx;video/msvideo;video/x-msvideo;video/ogg;video/quicktime;video/vnd.rn-realvideo;video/x-ms-afs;video/x-ms-asf;audio/x-ms-asf;application/vnd.ms-asf;video/x-ms-wmv;video/x-ms-wmx;video/x-ms-wvxvideo;video/x-avi;video/avi;video/x-flic;video/fli;video/x-flc;video/flv;video/x-flv;video/x-theora;video/x-theora+ogg;video/x-matroska;video/mkv;audio/x-matroska;application/x-matroska;video/webm;audio/webm;audio/vorbis;audio/x-vorbis;audio/x-vorbis+ogg;video/x-ogm;video/x-ogm+ogg;application/x-ogm;application/x-ogm-audio;application/x-ogm-video;application/x-shorten;audio/x-shorten;audio/x-ape;audio/x-wavpack;audio/x-tta;audio/AMR;audio/ac3;audio/eac3;audio/amr-wb;video/mp2t;audio/flac;audio/mp4;application/x-mpegurl;video/vnd.mpegurl;application/vnd.apple.mpegurl;audio/x-pn-au;video/3gp;video/3gpp;video/3gpp2;audio/3gpp;audio/3gpp2;video/dv;audio/dv;audio/opus;audio/vnd.dts;audio/vnd.dts.hd;audio/x-adpcm;application/x-cue;audio/m3u;audio/vnd.wave;video/vnd.avi;inode/directory;
+ X-KDE-Protocols=appending,file,ftp,hls,http,https,mms,mpv,rist,rtmp,rtmps,rtmpt,rtmpts,rtp,rtsp,rtsps,sftp,srt,srtp,webdav,webdavs
+ X-DBUS-ServiceName=
+-- 
+2.53.0
+


### PR DESCRIPTION
Plasma Discover uses the "Audio" and "Video" categories to exclude apps from respectively video and audio players categories.
The "AudioVideo" category already covers both.